### PR TITLE
Update Get-MailboxRules.ps1

### DIFF
--- a/PowerShellScripts/Get-MailboxRules.ps1
+++ b/PowerShellScripts/Get-MailboxRules.ps1
@@ -1,25 +1,24 @@
 <#
 Author: Lee Christensen (@tifkin_)
+Edited by: Josh M. Bryant (@FixTheExchange)
 License: BSD 3-Clause
-Required Dependencies: None
+Required Dependencies: EWS API 2.2 https://www.microsoft.com/en-us/download/details.aspx?id=42951
 Optional Dependencies: None
 #>
 
-Import-Module -Name "C:\Program Files\Microsoft\Exchange\Web Services\2.2\Microsoft.Exchange.WebServices.dll"
+Add-Type -Path 'C:\Program Files\Microsoft\Exchange\Web Services\2.2\Microsoft.Exchange.WebServices.dll'
 
 if(!$Creds)
 {
-    $Creds = $Host.UI.PromptForCredential("Credentials", "Please enter your email/password", "", "").GetNetworkCredential()
+    $Creds = Get-Credential
 }
 $emailAddress = $Creds.UserName
 $password = $Creds.Password
 
-$exchService = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2013_SP1, [System.TimeZoneInfo]::Local)
-
-$exchService.Credentials = new-object System.Net.NetworkCredential($UserName, $password, "") 
-#$exchService.AutodiscoverUrl($email, {$true})
-
-$exchService.Url = New-Object System.Uri("https://outlook.office365.com/EWS/Exchange.asmx") 
+$exchService = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService
+$exchService.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials -ArgumentList $emailAddress, $password
+#Autodiscover, there is no other, way to decide where you're mailbox is stored...
+$exchService.AutodiscoverUrl($emailAddress, {$true})
 
 $mbx = New-Object Microsoft.Exchange.WebServices.Data.Mailbox($emailAddress)
 


### PR DESCRIPTION
Simplified a couple of lines and fixed it so it uses Autodiscover instead of the hardcoded URL.  The output doesn't seem to be useful though. It seems the actions for client-side rules aren't exposed to Exchange. So while we can differentiate between server and client side rules, we can't tell what the client side rule is doing. Here's another way of looking at it, but it doesn't give anything useful either...
# Load EWS API 2.2 (https://www.microsoft.com/en-us/download/details.aspx?id=42951)

Add-Type -Path 'C:\Program Files\Microsoft\Exchange\Web Services\2.2\Microsoft.Exchange.WebServices.dll'
# Securely prompt for credentials (For Proof of concept only, attacker could use plaintext to process lists of credentials)

$Credential = Get-Credential
# Specify what mailbox we're going to work with.

$Mailbox = "user@domain.com"
# Connect to EWS with our credentials.

$EWS = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService
$EWS.Credentials = New-Object Microsoft.Exchange.WebServices.Data.WebCredentials -ArgumentList $Credential.UserName, $Credential.GetNetworkCredential().Password
# Autodiscover, there is no other, way to decide where you're mailbox is stored...

$EWS.AutodiscoverURL($Mailbox,{$true})
# Display all rules for the current mailbox.

$Rules = $EWS.GetInboxRules() | Where {$_.DisplayName -eq "OutlookPWN!"}
ForEach ($Rule in $Rules) {
Write-Host "DisplayName:" $Rule.DisplayName
Write-Host "Actions: "
$Rule.Actions | Get-Member
}
